### PR TITLE
支持https

### DIFF
--- a/smzdm_daily.py
+++ b/smzdm_daily.py
@@ -18,7 +18,7 @@ class SMZDMDailyException(Exception):
         return str(self.req)
 
 class SMZDMDaily(object):
-    BASE_URL = 'http://zhiyou.smzdm.com'
+    BASE_URL = 'https://zhiyou.smzdm.com'
     LOGIN_URL = BASE_URL + '/user/login/ajax_check'
     CHECKIN_URL = BASE_URL + '/user/checkin/jsonp_checkin'
 
@@ -39,9 +39,9 @@ class SMZDMDaily(object):
             'password': self.password,
         }
 
-        r = self.session.get(self.BASE_URL, headers=headers, verify=False)
-        r = self.session.post(self.LOGIN_URL, data=params, headers=headers, verify=False)
-        r = self.session.get(self.CHECKIN_URL, headers=headers, verify=False)
+        r = self.session.get(self.BASE_URL, headers=headers, verify=True)
+        r = self.session.post(self.LOGIN_URL, data=params, headers=headers, verify=True)
+        r = self.session.get(self.CHECKIN_URL, headers=headers, verify=True)
         if r.status_code != 200:
             raise SMZDMDailyException(r)
 


### PR DESCRIPTION
之前会报错，提示先登录
`C:\Python27\lib\site-packages\urllib3\connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
C:\Python27\lib\site-packages\urllib3\connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
C:\Python27\lib\site-packages\urllib3\connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
C:\Python27\lib\site-packages\urllib3\connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
C:\Python27\lib\site-packages\urllib3\connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
('success', {u'data': [], u'error_code': 99, u'error_msg': u'\u8bf7\u5148\u767b\u5f55'})`

现在能正常化登录了
`('success', {u'data': {u'slogan': u'<div class="signIn_data">\u4eca\u65e5\u5df2\u9886<span class="red">30</span>\u79ef\u5206</div>', u'gold': 6, u'point': 3917, u'add_point': 30, u'rank': 12, u'checkin_num': 79, u'exp': 4229, u'prestige': 0}, u'error_code': 0, u'error_msg': u''})`